### PR TITLE
Show contribution amounts

### DIFF
--- a/contract/contracts/CrowdFund.sol
+++ b/contract/contracts/CrowdFund.sol
@@ -245,6 +245,10 @@ contract CrowdFund {
         return contributors[contributorAddress].milestoneNoVotes[milestoneIndex];
     }
 
+    function getContributorContributionAmount(address contributorAddress) public view returns (uint) {
+        return contributors[contributorAddress].contributionAmount;
+    }
+
     modifier onlyFrozen() {
         require(frozen, "CrowdFund is not frozen");
         _;

--- a/contract/test/CrowdFundTest.js
+++ b/contract/test/CrowdFundTest.js
@@ -422,4 +422,16 @@ contract("CrowdFund", accounts => {
     assert.equal(true, milestoneVote)
   });
 
+
+  // [END] getContributorMilestoneVote
+
+  // [BEGIN] getContributorContributionAmount
+
+  it("returns amount a contributor has contributed", async () => {
+    const constributionAmount = raiseGoal / 5 
+    await crowdFund.contribute({ from: thirdAccount, value: constributionAmount });
+    const contractContributionAmount = await crowdFund.getContributorContributionAmount(thirdAccount)
+    assert.equal(contractContributionAmount.toNumber(), constributionAmount)
+  });
+
 });


### PR DESCRIPTION
Partially implements https://github.com/grant-project/grant-monorepo/issues/8

## What this does
Adds a `getContributorContributionAmount` function to access contributors' contribution amounts.


### To test
~run `yarn test` in `/contracts`, and verify that the test correctly checks behavior of the function.~
1. Review contract changes for reasonable changes
2. Check that CI passes successfully 😁 