### PR TITLE
Show Proposal Contribution Amounts

### DIFF
--- a/frontend/client/components/CreateProposal/index.tsx
+++ b/frontend/client/components/CreateProposal/index.tsx
@@ -177,7 +177,6 @@ class CreateProposal extends React.Component<Props, State> {
     const milestoneAmounts = milestones.map(milestone =>
       Wei(milestoneToMilestoneAmount(milestone, targetInWei)),
     );
-    console.log('milestoneAmounts', milestoneAmounts);
     const immediateFirstMilestonePayout = milestones[0].immediatePayout;
 
     const contractData = {

--- a/frontend/client/components/Proposal/Contributors/index.tsx
+++ b/frontend/client/components/Proposal/Contributors/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Spin } from 'antd';
+import { CrowdFund } from 'modules/proposals/reducers';
+import UserRow from 'components/UserRow';
+import * as ProposalStyled from '../styled';
+
+interface Props {
+  crowdFund: CrowdFund;
+}
+
+const ContributorsBlock = ({ crowdFund }: Props) => {
+  let content;
+  if (crowdFund) {
+    content = crowdFund.contributors.map(contributor => (
+      <UserRow
+        key={contributor.address}
+        address={contributor.address}
+        amount={contributor.contributionAmount}
+      />
+    ));
+  } else {
+    content = <Spin />;
+  }
+
+  return (
+    <ProposalStyled.SideBlock>
+      <ProposalStyled.BlockTitle>Contributors</ProposalStyled.BlockTitle>
+      <ProposalStyled.Block>{content}</ProposalStyled.Block>
+    </ProposalStyled.SideBlock>
+  );
+};
+
+export default ContributorsBlock;

--- a/frontend/client/components/Proposal/Contributors/index.tsx
+++ b/frontend/client/components/Proposal/Contributors/index.tsx
@@ -3,9 +3,8 @@ import { Spin } from 'antd';
 import { CrowdFund } from 'modules/proposals/reducers';
 import UserRow from 'components/UserRow';
 import * as ProposalStyled from '../styled';
-import Placeholder from '../../Placeholder';
-import { fromWei } from '../../../utils/units';
-import UnitDisplay from '../../UnitDisplay';
+import Placeholder from 'components/Placeholder';
+import UnitDisplay from 'components/UnitDisplay';
 
 interface Props {
   crowdFund: CrowdFund;

--- a/frontend/client/components/Proposal/Contributors/index.tsx
+++ b/frontend/client/components/Proposal/Contributors/index.tsx
@@ -3,6 +3,9 @@ import { Spin } from 'antd';
 import { CrowdFund } from 'modules/proposals/reducers';
 import UserRow from 'components/UserRow';
 import * as ProposalStyled from '../styled';
+import Placeholder from '../../Placeholder';
+import { fromWei } from '../../../utils/units';
+import UnitDisplay from '../../UnitDisplay';
 
 interface Props {
   crowdFund: CrowdFund;
@@ -16,11 +19,20 @@ const ContributorsBlock = ({ crowdFund }: Props) => {
         <UserRow
           key={contributor.address}
           address={contributor.address}
-          amount={contributor.contributionAmount}
+          secondary={<UnitDisplay value={contributor.contributionAmount} symbol="ETH" />}
         />
       ));
     } else {
-      content = <h5>No contributors found.</h5>;
+      content = (
+        <Placeholder
+          style={{ minHeight: '220px' }}
+          title="No contributors found"
+          subtitle={`
+            It appears that your campaign hasn't yet been funded.
+            Check back later once you've received at least one contribution!
+          `}
+        />
+      );
     }
   } else {
     content = <Spin />;

--- a/frontend/client/components/Proposal/Contributors/index.tsx
+++ b/frontend/client/components/Proposal/Contributors/index.tsx
@@ -11,21 +11,31 @@ interface Props {
 const ContributorsBlock = ({ crowdFund }: Props) => {
   let content;
   if (crowdFund) {
-    content = crowdFund.contributors.map(contributor => (
-      <UserRow
-        key={contributor.address}
-        address={contributor.address}
-        amount={contributor.contributionAmount}
-      />
-    ));
+    if (crowdFund.contributors.length) {
+      content = crowdFund.contributors.map(contributor => (
+        <UserRow
+          key={contributor.address}
+          address={contributor.address}
+          amount={contributor.contributionAmount}
+        />
+      ));
+    } else {
+      content = <h5>No contributors found.</h5>;
+    }
   } else {
     content = <Spin />;
   }
 
   return (
     <ProposalStyled.SideBlock>
-      <ProposalStyled.BlockTitle>Contributors</ProposalStyled.BlockTitle>
-      <ProposalStyled.Block>{content}</ProposalStyled.Block>
+      {crowdFund.contributors.length ? (
+        <>
+          <ProposalStyled.BlockTitle>Contributors</ProposalStyled.BlockTitle>
+          <ProposalStyled.Block>{content}</ProposalStyled.Block>
+        </>
+      ) : (
+        content
+      )}
     </ProposalStyled.SideBlock>
   );
 };

--- a/frontend/client/components/Proposal/index.tsx
+++ b/frontend/client/components/Proposal/index.tsx
@@ -15,6 +15,7 @@ import Milestones from './Milestones';
 import CommentsTab from './Comments';
 import UpdatesTab from './Updates';
 import GovernanceTab from './Governance';
+import ContributorsTab from './Contributors';
 // import CommunityTab from './Community';
 import * as Styled from './styled';
 import { withRouter } from 'next/router';
@@ -113,8 +114,11 @@ class ProposalDetail extends React.Component<Props, State> {
                 <div style={{ marginTop: '1.5rem' }} />
                 <UpdatesTab proposalId={proposal.proposalId} />
               </Tabs.TabPane>
-              <Tabs.TabPane tab="Governance" key="governanc">
+              <Tabs.TabPane tab="Governance" key="governance">
                 <GovernanceTab proposal={proposal} />
+              </Tabs.TabPane>
+              <Tabs.TabPane tab="Contributors" key="contributors">
+                <ContributorsTab crowdFund={proposal.crowdFund} />
               </Tabs.TabPane>
             </Tabs>
           )}

--- a/frontend/client/components/UserRow/index.tsx
+++ b/frontend/client/components/UserRow/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import ShortAddress from 'components/ShortAddress';
 import Identicon from 'components/Identicon';
 import * as Styled from './styled';
+import { Wei, fromWei } from 'utils/units';
 
 interface Props {
   address: string;
+  amount?: Wei;
 }
 
-// TODO - don't hardcode monero image
-
-const UserRow = ({ address }: Props) => (
+const UserRow = ({ address, amount }: Props) => (
   <Styled.Container>
     <Styled.Avatar>
       <Identicon address={address} />
@@ -18,7 +18,9 @@ const UserRow = ({ address }: Props) => (
       <Styled.InfoMain>
         <ShortAddress address={address} />
       </Styled.InfoMain>
-      <Styled.InfoSecondary>{/* user.title */}</Styled.InfoSecondary>
+      {amount && (
+        <Styled.InfoSecondary>{fromWei(amount, 'ether')} ETH</Styled.InfoSecondary>
+      )}
     </Styled.Info>
   </Styled.Container>
 );

--- a/frontend/client/components/UserRow/index.tsx
+++ b/frontend/client/components/UserRow/index.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import ShortAddress from 'components/ShortAddress';
 import Identicon from 'components/Identicon';
 import * as Styled from './styled';
-import { Wei, fromWei } from 'utils/units';
 
 interface Props {
   address: string;
-  amount?: Wei;
+  secondary?: React.ReactNode;
 }
 
-const UserRow = ({ address, amount }: Props) => (
+const UserRow = ({ address, secondary }: Props) => (
   <Styled.Container>
     <Styled.Avatar>
       <Identicon address={address} />
@@ -18,9 +17,7 @@ const UserRow = ({ address, amount }: Props) => (
       <Styled.InfoMain>
         <ShortAddress address={address} />
       </Styled.InfoMain>
-      {amount && (
-        <Styled.InfoSecondary>{fromWei(amount, 'ether')} ETH</Styled.InfoSecondary>
-      )}
+      {secondary && <Styled.InfoSecondary>{secondary}</Styled.InfoSecondary>}
     </Styled.Info>
   </Styled.Container>
 );

--- a/frontend/client/modules/proposals/reducers.ts
+++ b/frontend/client/modules/proposals/reducers.ts
@@ -14,7 +14,7 @@ export interface User {
 
 export interface Contributor {
   address: string;
-  contributionAmount: string;
+  contributionAmount: Wei;
   refundVote: boolean;
   refunded: boolean;
   proportionalContribution: string;

--- a/frontend/client/modules/web3/actions.ts
+++ b/frontend/client/modules/web3/actions.ts
@@ -7,6 +7,7 @@ import { sleep } from 'utils/helpers';
 import { fetchProposal, fetchProposals } from 'modules/proposals/actions';
 import { PROPOSAL_CATEGORY } from 'api/constants';
 import { AppState } from 'store/reducers';
+import { Wei } from 'utils/units';
 
 type GetState = () => AppState;
 
@@ -97,10 +98,10 @@ interface MilestoneData {
 }
 
 interface ProposalContractData {
-  ethAmount: number | string; // TODO: BigNumber
+  ethAmount: Wei;
   payOutAddress: string;
   trusteesAddresses: string[];
-  milestoneAmounts: number[] | string[]; // TODO: BigNumber
+  milestoneAmounts: Wei[];
   milestones: MilestoneData[];
   durationInMinutes: number;
   milestoneVotingPeriodInMinutes: number;

--- a/frontend/client/utils/helpers.ts
+++ b/frontend/client/utils/helpers.ts
@@ -5,7 +5,3 @@ export function isNumeric(n: any) {
 export async function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
-
-export function computePercentage(num: number, percent: number) {
-  return (num / 100) * percent;
-}

--- a/frontend/client/utils/units.ts
+++ b/frontend/client/utils/units.ts
@@ -38,7 +38,7 @@ export const Units = {
   gether: '1000000000000000000000000000',
   tether: '1000000000000000000000000000000',
 };
-const handleValues = (input: string | BN | number) => {
+const handleValues = (input: string | BN) => {
   if (typeof input === 'string') {
     return input.startsWith('0x') ? new BN(stripHexPrefix(input), 16) : new BN(input);
   }
@@ -58,7 +58,7 @@ const Data = (input: string) => toBuffer(addHexPrefix(input));
 
 const Nonce = (input: string | BN) => handleValues(input);
 
-const Wei = (input: string | BN | number): Wei => handleValues(input);
+const Wei = (input: string | BN): Wei => handleValues(input);
 
 const TokenValue = (input: string | BN) => handleValues(input);
 

--- a/frontend/client/utils/units.ts
+++ b/frontend/client/utils/units.ts
@@ -38,7 +38,7 @@ export const Units = {
   gether: '1000000000000000000000000000',
   tether: '1000000000000000000000000000000',
 };
-const handleValues = (input: string | BN) => {
+const handleValues = (input: string | BN | number) => {
   if (typeof input === 'string') {
     return input.startsWith('0x') ? new BN(stripHexPrefix(input), 16) : new BN(input);
   }
@@ -58,7 +58,7 @@ const Data = (input: string) => toBuffer(addHexPrefix(input));
 
 const Nonce = (input: string | BN) => handleValues(input);
 
-const Wei = (input: string | BN): Wei => handleValues(input);
+const Wei = (input: string | BN | number): Wei => handleValues(input);
 
 const TokenValue = (input: string | BN) => handleValues(input);
 
@@ -93,7 +93,13 @@ const fromWei = (wei: Wei, unit: UnitKey) => {
   return baseToConvertedUnit(wei.toString(), decimal);
 };
 
-const toWei = (value: string, decimal: number): Wei => {
+const toWei = (value: string, unitType: number | UnitKey): Wei => {
+  let decimal;
+  if (typeof unitType === 'number') {
+    decimal = unitType;
+  } else if (typeof unitType === 'string') {
+    decimal = getDecimalFromEtherUnit(unitType);
+  }
   const wei = convertedToBaseUnit(value, decimal);
   return Wei(wei);
 };

--- a/frontend/client/web3interact/crowdFund.ts
+++ b/frontend/client/web3interact/crowdFund.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3';
 import { CrowdFund, Milestone, MILESTONE_STATE } from 'modules/proposals/reducers';
 import { collectArrayElements } from 'utils/web3Utils';
 import { Wei } from 'utils/units';
+import BN from 'bn.js';
 
 export async function getCrowdFundState(
   crowdFundContract: any,
@@ -26,7 +27,10 @@ export async function getCrowdFundState(
     ? 100
     : balance.divn(100).isZero()
       ? 0
-      : target.div(balance.divn(100)).toNumber();
+      : balance
+          .mul(new BN(100))
+          .divRound(target)
+          .toNumber();
   const amountVotingForRefund = isRaiseGoalReached
     ? Wei(await crowdFundContract.methods.amountVotingForRefund().call({ from: account }))
     : Wei('0');
@@ -102,6 +106,11 @@ export async function getCrowdFundState(
               .getContributorMilestoneVote(addr, idx)
               .call({ form: account }),
         ),
+      );
+      contributor.contributionAmount = Wei(
+        await crowdFundContract.methods
+          .getContributorContributionAmount(addr)
+          .call({ from: account }),
       );
       return contributor;
     }),

--- a/frontend/client/web3interact/crowdFund.ts
+++ b/frontend/client/web3interact/crowdFund.ts
@@ -29,7 +29,7 @@ export async function getCrowdFundState(
       ? 0
       : balance
           .mul(new BN(100))
-          .divRound(target)
+          .div(target)
           .toNumber();
   const amountVotingForRefund = isRaiseGoalReached
     ? Wei(await crowdFundContract.methods.amountVotingForRefund().call({ from: account }))


### PR DESCRIPTION
Depends on https://github.com/grant-project/grant-monorepo/pull/48
Closes https://github.com/grant-project/grant-monorepo/issues/8

## What this does
Shows contributors and their respective contribution amounts in a new contributors tab.<sub><sub>Say that 5 times fast</sub></sub>

Other changes include:
- Fix funding progress calculation (percentage was > 100 after funding any amount. Probably regressed during the BN switchover)
- Fix BN types
- Add contributors tab
- Adjust UserRow to optionally show amount as secondary text
- Add contributionAmount to contributors in crowdFund
- General cleanup


<img width="1010" alt="screen shot 2018-09-16 at 1 23 09 am" src="https://user-images.githubusercontent.com/7861465/45593748-94d14680-b952-11e8-8874-8581ed10f1e3.png">

<img width="1113" alt="screen shot 2018-09-16 at 2 57 39 pm" src="https://user-images.githubusercontent.com/7861465/45600348-e44e5b80-b9c0-11e8-8fb1-43688ce13a6d.png">
