### PR TITLE
Disable typescript checking during dev build via .env

### DIFF
--- a/frontend/.envexample
+++ b/frontend/.envexample
@@ -1,2 +1,5 @@
 # Funds these addresses when `npm run truffle` runs. Comma separated.
 FUND_ETH_ADDRESSES=0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520,0xDECAF9CD2367cdbb726E904cD6397eDFcAe6068DEe0460DFa261520,0xDECAF9CD2367cdbb726E904cD6397eDFcAe6068D
+
+# Disable typescript checking for dev building (reduce build time & resource usage)
+NO_DEV_TS_CHECK=true

--- a/frontend/config/webpack.config.js/client.dev.js
+++ b/frontend/config/webpack.config.js/client.dev.js
@@ -4,20 +4,22 @@ const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
+const isTsCheck = process.env.NO_DEV_TS_CHECK !== 'true';
+
 const config = {
   ...baseConfig,
   plugins: [
     new WriteFileWebpackPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     ...baseConfig.plugins,
-    new ForkTsCheckerWebpackPlugin(),
+    isTsCheck && new ForkTsCheckerWebpackPlugin(),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
       reportFilename: '../../dev-client-bundle-analysis.html',
       defaultSizes: 'gzip',
       openAnalyzer: false,
     }),
-  ],
+  ].filter(Boolean),
   mode: 'development',
   devtool: 'cheap-module-inline-source-map',
   performance: {

--- a/frontend/config/webpack.config.js/server.dev.js
+++ b/frontend/config/webpack.config.js/server.dev.js
@@ -3,13 +3,15 @@ const webpack = require('webpack');
 const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
+const isTsCheck = process.env.NO_DEV_TS_CHECK !== 'true';
+
 const config = {
   ...baseConfig,
   plugins: [
     new WriteFileWebpackPlugin(),
     ...baseConfig.plugins,
-    new ForkTsCheckerWebpackPlugin(),
-  ],
+    isTsCheck && new ForkTsCheckerWebpackPlugin(),
+  ].filter(Boolean),
   mode: 'development',
   performance: {
     hints: false,


### PR DESCRIPTION
Closes #58 
### What this does
- adds `NO_DEV_TS_CHECK` env variable to opt out of dev build typescript checking

### Testing
- `yarn dev` and observe something like the following in console:
```
Starting type checking service...
Using 1 worker with 2048MB memory limit
Starting type checking service...
Using 1 worker with 2048MB memory limit

...

No type errors found
Version: typescript 3.0.3
Time: 11014ms
No type errors found
Version: typescript 3.0.3
Time: 11057ms
```
- add `NO_DEV_TS_CHECK=true` to your `/.env` file
- `yarn dev` and observe the omission of the above output