### PR TITLE
Prevent helmet crash

### DIFF
--- a/frontend/client/components/BasicHead.tsx
+++ b/frontend/client/components/BasicHead.tsx
@@ -15,12 +15,9 @@ class BasicHead extends React.Component<Props> {
     const { children, title } = this.props;
     const defaultOgpUrl = process.env.PUBLIC_HOST_URL + this.props.location.pathname;
     const defaultOgpImage = urlToPublic(ogpLogo);
-    // TODO: Remove once react-helmet is updated
-    // https://github.com/nfl/react-helmet/issues/373
-    const key = typeof window !== 'undefined' ? window.location.href : 'ssr';
     return (
       <div>
-        <Helmet key={key}>
+        <Helmet>
           <title>{`Grant.io - ${title}`}</title>
           <meta name={`${title} page`} content={`${title} page stuff`} />
           <link

--- a/frontend/client/components/BasicHead.tsx
+++ b/frontend/client/components/BasicHead.tsx
@@ -15,9 +15,12 @@ class BasicHead extends React.Component<Props> {
     const { children, title } = this.props;
     const defaultOgpUrl = process.env.PUBLIC_HOST_URL + this.props.location.pathname;
     const defaultOgpImage = urlToPublic(ogpLogo);
+    // TODO: Remove once react-helmet is updated
+    // https://github.com/nfl/react-helmet/issues/373
+    const key = typeof window !== 'undefined' ? window.location.href : 'ssr';
     return (
       <div>
-        <Helmet>
+        <Helmet key={key}>
           <title>{`Grant.io - ${title}`}</title>
           <meta name={`${title} page`} content={`${title} page stuff`} />
           <link

--- a/frontend/client/components/HeaderDetails.tsx
+++ b/frontend/client/components/HeaderDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
-import { urlToPublic } from 'utils/helpers';
+// import { Helmet } from 'react-helmet';
+// import { urlToPublic } from 'utils/helpers';
 
 interface Props {
   title: string;
@@ -12,25 +12,25 @@ interface Props {
 
 export default class HeaderDetails extends React.Component<Props> {
   render() {
-    const { title, image, url, type, description } = this.props;
-    // TODO: Remove once react-helmet is updated
+    // TODO: Uncomment once helmet is fixed
     // https://github.com/nfl/react-helmet/issues/373
-    const key = typeof window !== 'undefined' ? window.location.href : 'ssr';
-    return (
-      <Helmet key={key}>
-        <title>{`Grant.io - ${title}`}</title>
-        {/* open graph protocol */}
-        {type && <meta property="og:type" content="website" />}
-        <meta property="og:title" content={title} />
-        {description && <meta property="og:description" content={description} />}
-        {url && <meta property="og:url" content={urlToPublic(url)} />}
-        {image && <meta property="og:image" content={urlToPublic(image)} />}
-        {/* twitter card */}
-        <meta property="twitter:title" content={title} />
-        {description && <meta property="twitter:description" content={description} />}
-        {url && <meta property="twitter:url" content={urlToPublic(url)} />}
-        {image && <meta property="twitter:image" content={urlToPublic(image)} />}
-      </Helmet>
-    );
+    return null;
+    // const { title, image, url, type, description } = this.props;
+    // return (
+    //   <Helmet>
+    //     <title>{`Grant.io - ${title}`}</title>
+    //     {/* open graph protocol */}
+    //     {type && <meta property="og:type" content="website" />}
+    //     <meta property="og:title" content={title} />
+    //     {description && <meta property="og:description" content={description} />}
+    //     {url && <meta property="og:url" content={urlToPublic(url)} />}
+    //     {image && <meta property="og:image" content={urlToPublic(image)} />}
+    //     {/* twitter card */}
+    //     <meta property="twitter:title" content={title} />
+    //     {description && <meta property="twitter:description" content={description} />}
+    //     {url && <meta property="twitter:url" content={urlToPublic(url)} />}
+    //     {image && <meta property="twitter:image" content={urlToPublic(image)} />}
+    //   </Helmet>
+    // );
   }
 }

--- a/frontend/client/components/HeaderDetails.tsx
+++ b/frontend/client/components/HeaderDetails.tsx
@@ -13,8 +13,11 @@ interface Props {
 export default class HeaderDetails extends React.Component<Props> {
   render() {
     const { title, image, url, type, description } = this.props;
+    // TODO: Remove once react-helmet is updated
+    // https://github.com/nfl/react-helmet/issues/373
+    const key = typeof window !== 'undefined' ? window.location.href : 'ssr';
     return (
-      <Helmet>
+      <Helmet key={key}>
         <title>{`Grant.io - ${title}`}</title>
         {/* open graph protocol */}
         {type && <meta property="og:type" content="website" />}


### PR DESCRIPTION
Uses the `key` trick suggested in https://github.com/nfl/react-helmet/issues/373 to prevent helmet from crashing due to greedy deepEquals check.